### PR TITLE
Basic working prototype

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'assert', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ansi (1.4.3)
+    assert (1.0.0)
+      ansi (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  assert (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -15,24 +15,18 @@ cli = CLI.new do
   option :thing, "set thing", :default => "AThing"
 end
 
-# given `cli --verbose some other args`
-cli.opts   # => {:severity => 4, :verbose => true, :thing => "AThing"}
-cli.args   # => ["some", "other", "args"]
-cli.explain_opts # =>
-# "-s, --severity 4           set severity"\
-# "-v, --[no-]verbose         enable verbose output"\
-# "-m, --mutation ATHing      set mutation"\
-# "-h, --help                 Show this message"\
-# "-V, --version              Print version"
+cli.parse! ['--verbose', 'some', 'other', 'args']
+cli.opts  # => {:severity => 4, :verbose => true, :thing => "AThing"}
+cli.args  # => ["some", "other", "args"]
 ```
 
-# Features
+## Features
 
 There is no install, no dependency to manage.  Just copy in `cli.rb` to your project and use it.
 
 It does no validations or handling.  It only parses the options from the arguments and provides readers for them
 
-# Notes
+## Notes
 
 * You must define default values, if the option should accept an argument. Every option without a default value (or with `true` or `false` as default) is treated as a switch.
 * It is not possible to define mandatory / required arguments

--- a/cli.rb
+++ b/cli.rb
@@ -1,1 +1,54 @@
-# TODO
+class CLI  # Version 0.0.1, https://github.com/redding/cli.rb
+  OptsParseError = Class.new(RuntimeError)
+  attr_reader :argv, :args, :opts
+
+  def initialize(&block)
+    @options = []; instance_eval(&block) if block
+    require 'optparse'
+    @arg, @opts = [], {}; @parser = OptionParser.new do |p|
+      p.banner = ''; @options.each do |o|
+        @opts[o.name] = o.default; p.on(*o.parser_args){ |v| @opts[o.name] = v }
+      end
+      a = @options.map(&:abbrev).include?('v') ? 'V' : 'v'
+      p.on_tail("-#{a}", "--version", ''){ |v| throw 'version', v }
+      p.on_tail("-h", "--help", ''){ |v| throw 'help', @parser.to_s.strip }
+    end
+  end
+
+  def parse!(argv=nil)
+    @args = (argv || ARGV).dup.tap do |args_list|
+      begin; @parser.parse!(args_list)
+      rescue OptionParser::ParseError => err; raise OptsParseError, err.message; end
+    end
+  end
+  def option(*args); @options << Option.new(*args); end
+  def inspect
+    "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @args=#{@args.inspect}, @opts=#{@opts.inspect}>"
+  end
+
+  class Option
+    attr_reader :name, :opt_name, :desc, :abbrev, :default, :klass, :parser_args
+
+    def initialize(name, *args)
+      settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+      @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
+      @default, @klass = get_default_settings(settings)
+      @parser_args = if [TrueClass, FalseClass].include?(@klass)
+        ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
+      else
+        ["-#{@abbrev}", "--#{@opt_name} #{@default}", @klass, @desc]
+      end
+    end
+
+    private
+
+    def parse_name_values(name, custom_abbrev)
+      [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
+        custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+      ]
+    end
+    def get_default_settings(settings)
+      [ (val = settings[:default] || false), val.class == Fixnum ? Integer : val.class ]
+    end
+  end
+end

--- a/test/cli_tests.rb
+++ b/test/cli_tests.rb
@@ -1,0 +1,131 @@
+require 'assert'
+
+class CLITests < Assert::Context
+  desc "CLI"
+  setup do
+    @cli = CLI.new
+  end
+  subject { @cli }
+
+  should have_imeths :option, :to_s, :parse!
+  should have_readers :args, :opts
+
+  def catch_thrown(cli, thrown, *argv)
+    catch(thrown){ cli.parse! argv }
+  end
+
+  should "operate on ARGV by default" do
+    assert_equal [], ARGV
+    subject.parse!
+    assert_empty subject.args
+    assert_empty subject.opts
+  end
+
+end
+
+class VersionTests < CLITests
+
+  should "catch `version` when parsing `-v` when with no other 'v' opts" do
+    val = catch_thrown CLI.new, 'version', '-v'
+    assert_equal true, val
+  end
+
+  should "catch `version` when parsing `-V` when with other 'v' opts" do
+    cli = CLI.new{ option 'verbose', 'verbosity'}
+    val = catch_thrown cli, 'version', '-V'
+    assert_equal true, val
+
+    cli = CLI.new{ option 'anopt', 'opt', :abbrev => 'v' }
+    val = catch_thrown cli, 'version', '-V'
+    assert_equal true, val
+  end
+
+end
+
+class HelpTests < CLITests
+
+  should "catch `help` when parsing `-h`" do
+    assert_nothing_raised { catch_thrown CLI.new, 'help', '-h' }
+  end
+
+  should "return an opts explanation message when catching `help`" do
+    exp_msg = "-v, --version\n    -h, --help"
+    val = catch_thrown CLI.new, 'help', '-h'
+    assert_equal exp_msg, val
+  end
+
+end
+
+class SwitchTests < CLITests
+  desc "when parsing a switch opt"
+  setup do
+    @cli = CLI.new{ option 'verbose', 'verbosity'}
+  end
+
+  should "default to false" do
+    subject.parse! []
+    assert_equal false, subject.opts['verbose']
+  end
+
+  should "set true if abbrev" do
+    subject.parse! ['-v']
+    assert_equal true, subject.opts['verbose']
+  end
+
+  should "set true if full" do
+    subject.parse! ['--verbose']
+    assert_equal true, subject.opts['verbose']
+  end
+
+  should "set false if full negative" do
+    subject.parse! ['--no-verbose']
+    assert_equal false, subject.opts['verbose']
+  end
+
+end
+
+class SingleValueTests < CLITests
+  desc "when parsing a single value opt"
+  setup do
+    @cli = CLI.new{ option 'skill', 'skillz', :default => '' }
+  end
+
+  should "set the default" do
+    subject.parse! []
+    assert_equal '', subject.opts['skill']
+  end
+
+  should "set the value if abbrev" do
+    subject.parse! ['-s', 'booyah']
+    assert_equal 'booyah', subject.opts['skill']
+  end
+
+  should "set the value if full" do
+    subject.parse! ['--skill', 'booyah']
+    assert_equal 'booyah', subject.opts['skill']
+  end
+
+  should "type-cast the value" do
+    cli = CLI.new{ option 'skill', 'skillz', :default => 1 }
+    cli.parse! ['-s', '12']
+    assert_equal 12, cli.opts['skill']
+  end
+
+end
+
+class ListValueTests < CLITests
+  desc "when parsing a list value opt"
+  setup do
+    @cli = CLI.new{ option 'skill', 'skillz', :default => [] }
+  end
+
+  should "set the list values by parsing the value as comma-separated" do
+    subject.parse! ['--skill', 'art,deco,eat,sleep']
+    assert_equal ['art', 'deco', 'eat', 'sleep'], subject.opts['skill']
+  end
+
+end
+
+class ArgsParsingTests < CLITests
+  # TODO
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,7 @@
+# this file is automatically required in when you require 'assert'
+# put test helpers here
+
+# add root dir to the load path
+$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+
+require 'cli'

--- a/test/option_tests.rb
+++ b/test/option_tests.rb
@@ -1,0 +1,89 @@
+require 'assert'
+
+class OptionTests < Assert::Context
+  desc "an Option"
+  setup do
+    @option = CLI::Option.new('test', "testing", :default => 'value')
+  end
+  subject{ @option }
+
+  should have_readers :name, :opt_name, :desc, :abbrev, :default, :klass, :parser_args
+
+  should "know its name and desc" do
+    assert_equal 'test', subject.name
+    assert_equal 'testing', subject.desc
+  end
+
+  should "know its default value and klass" do
+    assert_equal 'value', subject.default
+    assert_equal String,  subject.klass
+  end
+
+  should "know its defaults" do
+    opt_with_defaults = CLI::Option.new(:test)
+    assert_equal '',         opt_with_defaults.desc
+    assert_equal false,      opt_with_defaults.default
+    assert_equal FalseClass, opt_with_defaults.klass
+  end
+
+  should "force its name to a downcased string val" do
+    assert_equal 'test', CLI::Option.new(:Test).name
+  end
+
+  should "parse its opt_name from the name" do
+    assert_equal 'test',        CLI::Option.new('test').opt_name
+    assert_equal 'testit',      CLI::Option.new('TestIt').opt_name
+    assert_equal 'test-it',     CLI::Option.new('test_it').opt_name
+    assert_equal 'test-it',     CLI::Option.new('Test_it').opt_name
+    assert_equal 'test-it-now', CLI::Option.new('test_it-now').opt_name
+  end
+
+  should "parse its opt_abbrev from the first letter of the opt_name" do
+    assert_equal 't', CLI::Option.new('test').abbrev
+    assert_equal 'i', CLI::Option.new('it-test').abbrev
+    assert_equal 't', CLI::Option.new('123test').abbrev
+    assert_equal 't', CLI::Option.new('_test').abbrev
+    assert_equal 'a', CLI::Option.new('1234').abbrev
+  end
+
+  should "override its opt_abbrev with the :abbrev setting" do
+    assert_equal 'x', CLI::Option.new('test', '', :abbrev => 'x').abbrev
+  end
+
+  should "set the default_klass to Integer if given a Fixnum" do
+    assert_equal Integer, CLI::Option.new('test', '', :default => 1).klass
+  end
+
+  should "set the default_value to `false` if given a `nil` default" do
+    nil_opt = CLI::Option.new('test', '', :default => nil)
+    assert_equal false,      nil_opt.default
+    assert_equal FalseClass, nil_opt.klass
+  end
+
+end
+
+class SwitchOptTests < OptionTests
+  desc "that is a switch"
+  setup do
+    @option = CLI::Option.new('test', "testing")
+  end
+
+  should "use its opt_abbrev, opt_name, and desc in the parser_args" do
+    exp_args = ['-t', '--[no-]test', 'testing']
+    assert_equal exp_args, subject.parser_args
+  end
+
+end
+
+class ValueOptTests < OptionTests
+  desc "that is not a switch"
+  setup do
+    @option = CLI::Option.new('test', "testing", :default => 'value')
+  end
+
+  should "use abbrev, name with default, klass, and desc in the parser_args" do
+    exp_args = ['-t', '--test value', String, 'testing']
+    assert_equal exp_args, subject.parser_args
+  end
+
+end


### PR DESCRIPTION
@jcredding This is me trying to have something common to use when writing CLIs.

All this does is parse the `ARGV` for you and provide a list
of args and an option hash. It does no handling for you, no
validation, no help messages, no nothing except parse data.

For the common `-h` and `-v` help/version flags, it will throw
and your CLI should catch and handle this case.

It provides a clean option definition API for adding options to
parse.

The focus is:
- minimal, compact code (<60 loc)
- just parse data nicely for me
- clean option definition API

Anyway, look over this and give any feedback.  I'm going to put it into some previous CLIs I've written and do some further eval on it.
