### PR TITLE
rename class to `CLIRB` and suggest namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line argument parser for Ruby.
 ```ruby
 require 'cli'
 
-cli = CLI.new do
+cli = CLIRB.new do
   option :severity, "set severity", :value => 4
   option :verbose, "enable verbose output"
   option :thing, "set thing", :value => String
@@ -36,7 +36,7 @@ See the ['example file'](/example.rb) for details on usage and handling.
 
 ## Installation
 
-Copy the `cli.rb` file into your project and require it.
+Paste the contents of the `cli.rb` file into your project under its namespace (anyway you see fit) and use it.  Seriously, namespace your use of `CLIRB` so that you aren't referencing it from the global namespace (you'll help avoid conflicts with dependencies that also use cli.rb).
 
 ## Contributing
 

--- a/cli.rb
+++ b/cli.rb
@@ -1,4 +1,4 @@
-class CLI  # Version 0.1.0, https://github.com/redding/cli.rb
+class CLIRB  # Version 0.1.0, https://github.com/redding/cli.rb
   Error    = Class.new(RuntimeError);
   HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
   attr_reader :argv, :args, :opts, :data

--- a/example.rb
+++ b/example.rb
@@ -1,12 +1,12 @@
-# 1. require in the cli.rb code (you code also paste it as child class or something)
+# 1. require in the cli.rb code (or paste it as MyCLI child class or something)
 
-require 'cli'
+require 'mycli/cli'
 
-# 2. setup your CLI class, have it compose ::CLI (or sub-class or whatever)
+# 2. setup your CLI class, have it compose CLIRB (or sub-class or whatever)
 
 class MyCLI
   def initialize
-    @cli = ::CLI.new do
+    @cli = CLIRB.new do
       option :method, "method: line, word (default), or char", {
         :value => String
       }
@@ -27,8 +27,8 @@ class MyCLI
 # 3. inspect, validate, handle the opts and args
 
       a = @cli.args; aa = a.map(&:inspect).join(', ')
-      raise ::CLI::Error, "too few arguments (#{a.size}): #{aa}"  if a.size < 2
-      raise ::CLI::Error, "too many arguments (#{a.size}): #{aa}" if a.size > 2
+      raise CLIRB::Error, "too few arguments (#{a.size}): #{aa}"  if a.size < 2
+      raise CLIRB::Error, "too many arguments (#{a.size}): #{aa}" if a.size > 2
 
       @cli.opts['method'] ||= 'word'
       @cli.opts['format'] ||= 'ascii' if @cli.opts['ascii']
@@ -38,22 +38,22 @@ class MyCLI
 
       begin
 
-# 4. Use the CLI data in a handler or whatever
+# 4. Use CLIRB data in a handler or whatever
 
         MyHandler.new(*@cli.data).run
       rescue MyError => err
-        raise ::CLI::Error, err.message
+        raise CLIRB::Error, err.message
       end
 
-# 5. Use the CLI exceptions to handle different usage cases
+# 5. Use the CLIRB exceptions to handle different usage cases
 
-    rescue ::CLI::HelpExit
+    rescue CLIRB::HelpExit
       puts help_msg
       exit(0)
-    rescue ::CLI::VersionExit
+    rescue CLIRB::VersionExit
       puts MyCLI::VERSION
       exit(0)
-    rescue ::CLI::Error => err
+    rescue CLIRB::Error => err
       puts "#{err.message}\n\n"
       puts help_msg
       exit(1)

--- a/test/cli_tests.rb
+++ b/test/cli_tests.rb
@@ -3,7 +3,7 @@ require 'assert'
 class CLITests < Assert::Context
   desc "CLI"
   setup do
-    @cli = CLI.new
+    @cli = CLIRB.new
   end
   subject { @cli }
 
@@ -20,15 +20,15 @@ class CLITests < Assert::Context
   end
 
   should "raise `VersionExit` parsing `--version`" do
-    assert_raises(CLI::VersionExit) { cli_parse subject, '--version' }
+    assert_raises(CLIRB::VersionExit) { cli_parse subject, '--version' }
   end
 
   should "raise `HelpExit` when parsing `--help`" do
-    assert_raises(CLI::HelpExit) { cli_parse subject, '--help' }
+    assert_raises(CLIRB::HelpExit) { cli_parse subject, '--help' }
   end
 
   should "parse the args, opts, and full data" do
-    cli = CLI.new{ option 'verbose', 'verbosity'}
+    cli = CLIRB.new{ option 'verbose', 'verbosity'}
     cli_parse(cli, 'an', 'arg', '-v')
 
     assert_equal ['an', 'arg'], cli.args
@@ -42,7 +42,7 @@ end
 class SwitchTests < CLITests
   desc "when parsing a switch opt"
   setup do
-    @cli = CLI.new{ option 'verbose', 'verbosity'}
+    @cli = CLIRB.new{ option 'verbose', 'verbosity'}
   end
 
   should "default to niil" do
@@ -70,7 +70,7 @@ end
 class SingleValueTests < CLITests
   desc "when parsing a single value opt"
   setup do
-    @cli = CLI.new{ option 'skill', 'skillz', :value => '' }
+    @cli = CLIRB.new{ option 'skill', 'skillz', :value => '' }
   end
 
   should "set the default" do
@@ -89,7 +89,7 @@ class SingleValueTests < CLITests
   end
 
   should "type-cast the value" do
-    cli = CLI.new{ option 'skill', 'skillz', :value => 1 }
+    cli = CLIRB.new{ option 'skill', 'skillz', :value => 1 }
     cli.parse! ['-s', '12']
     assert_equal 12, cli.opts['skill']
   end
@@ -99,7 +99,7 @@ end
 class ListValueTests < CLITests
   desc "when parsing a list value opt"
   setup do
-    @cli = CLI.new{ option 'skill', 'skillz', :value => [] }
+    @cli = CLIRB.new{ option 'skill', 'skillz', :value => [] }
   end
 
   should "set the list values by parsing the value as comma-separated" do

--- a/test/option_tests.rb
+++ b/test/option_tests.rb
@@ -3,7 +3,7 @@ require 'assert'
 class OptionTests < Assert::Context
   desc "an Option"
   setup do
-    @option = CLI::Option.new('test', "testing", :value => 'value')
+    @option = CLIRB::Option.new('test', "testing", :value => 'value')
   end
   subject{ @option }
 
@@ -20,45 +20,45 @@ class OptionTests < Assert::Context
   end
 
   should "know its defaults" do
-    opt_with_defaults = CLI::Option.new(:test)
+    opt_with_defaults = CLIRB::Option.new(:test)
     assert_equal '',       opt_with_defaults.desc
     assert_equal nil,      opt_with_defaults.value
     assert_equal NilClass, opt_with_defaults.klass
   end
 
   should "force its name to a downcased string val" do
-    assert_equal 'test', CLI::Option.new(:Test).name
+    assert_equal 'test', CLIRB::Option.new(:Test).name
   end
 
   should "parse its opt_name from the name" do
-    assert_equal 'test',        CLI::Option.new('test').opt_name
-    assert_equal 'testit',      CLI::Option.new('TestIt').opt_name
-    assert_equal 'test-it',     CLI::Option.new('test_it').opt_name
-    assert_equal 'test-it',     CLI::Option.new('Test_it').opt_name
-    assert_equal 'test-it-now', CLI::Option.new('test_it-now').opt_name
+    assert_equal 'test',        CLIRB::Option.new('test').opt_name
+    assert_equal 'testit',      CLIRB::Option.new('TestIt').opt_name
+    assert_equal 'test-it',     CLIRB::Option.new('test_it').opt_name
+    assert_equal 'test-it',     CLIRB::Option.new('Test_it').opt_name
+    assert_equal 'test-it-now', CLIRB::Option.new('test_it-now').opt_name
   end
 
   should "parse its opt_abbrev from the first letter of the opt_name" do
-    assert_equal 't', CLI::Option.new('test').abbrev
-    assert_equal 'i', CLI::Option.new('it-test').abbrev
-    assert_equal 't', CLI::Option.new('123test').abbrev
-    assert_equal 't', CLI::Option.new('_test').abbrev
-    assert_equal 'a', CLI::Option.new('1234').abbrev
+    assert_equal 't', CLIRB::Option.new('test').abbrev
+    assert_equal 'i', CLIRB::Option.new('it-test').abbrev
+    assert_equal 't', CLIRB::Option.new('123test').abbrev
+    assert_equal 't', CLIRB::Option.new('_test').abbrev
+    assert_equal 'a', CLIRB::Option.new('1234').abbrev
   end
 
   should "override its opt_abbrev with the :abbrev setting" do
-    assert_equal 'x', CLI::Option.new('test', '', :abbrev => 'x').abbrev
+    assert_equal 'x', CLIRB::Option.new('test', '', :abbrev => 'x').abbrev
   end
 
   should "set its value to `nil` if given a Class :value" do
-    opt = CLI::Option.new('test', '', :value => String)
+    opt = CLIRB::Option.new('test', '', :value => String)
     assert_nil opt.value
     assert_equal String, opt.klass
   end
 
   should "set the klass to Integer if given a Fixnum" do
-    assert_equal Integer, CLI::Option.new('test', '', :value => 1).klass
-    assert_equal Integer, CLI::Option.new('test', '', :value => Fixnum).klass
+    assert_equal Integer, CLIRB::Option.new('test', '', :value => 1).klass
+    assert_equal Integer, CLIRB::Option.new('test', '', :value => Fixnum).klass
   end
 
 end
@@ -66,7 +66,7 @@ end
 class SwitchOptTests < OptionTests
   desc "that is a switch"
   setup do
-    @option = CLI::Option.new('test', "testing")
+    @option = CLIRB::Option.new('test', "testing")
   end
 
   should "use its opt_abbrev, opt_name, and desc in the parser_args" do
@@ -79,7 +79,7 @@ end
 class ValueOptTests < OptionTests
   desc "that is not a switch"
   setup do
-    @option = CLI::Option.new('thing', "testing", :value => 'value')
+    @option = CLIRB::Option.new('thing', "testing", :value => 'value')
   end
 
   should "use abbrev, name with VALUE, klass, and desc in the parser_args" do


### PR DESCRIPTION
Referencing `CLI` from the global namespace might be dangerous as
it is so generic (other things might define their own CLI classes).

This renames it to the more explicit `CLIRB` and suggests namespacing
it to help avoid these cases.

@jcredding FYI.  Will you pull this version into your stuff and test for me?
