### PR TITLE
remove Fixnum special handling; switch support to Ruby ~>2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 ruby "~> 2.4"
 
-gem 'assert', '~> 2.17.0'
+gem "assert", "~> 2.17.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
-gem 'assert', '~> 2.16.1'
+ruby "~> 2.4"
+
+gem 'assert', '~> 2.17.0'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-line argument parser for Ruby.
 ## Usage
 
 ```ruby
-require 'cli'
+require "cli"
 
 cli = CLIRB.new do
   option :severity, "set severity", :value => 4
@@ -13,7 +13,7 @@ cli = CLIRB.new do
   option :thing, "set thing", :value => String
 end
 
-cli.parse! ['--verbose', 'some', 'other', 'args']
+cli.parse! ["--verbose", "some", "other", "args"]
 cli.opts  #=> {:severity => 4, :verbose => true, :thing => nil}
 cli.args  #=> ["some", "other", "args"]
 cli.data  #=> ["some", "other", "args", {:severity => 4, :verbose => true, :thing => nil}]
@@ -35,7 +35,7 @@ cli.data  #=> ["some", "other", "args", {:severity => 4, :verbose => true, :thin
 
 ## Example
 
-See the ['example file'](/example.rb) for details on usage and handling.
+See the ["example file"](/example.rb) for details on usage and handling.
 
 ## Installation
 
@@ -45,6 +45,6 @@ Paste the contents of the `cli.rb` file into your project under a namespace (any
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Added some feature'`)
+3. Commit your changes (`git commit -am "Added some feature"`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request

--- a/cli.rb
+++ b/cli.rb
@@ -5,13 +5,13 @@ class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
 
   def initialize(&block)
     @options = []; instance_eval(&block) if block
-    require 'optparse'
+    require "optparse"
     @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
-      p.banner = ''; @options.each do |o|
+      p.banner = ""; @options.each do |o|
         @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
       end
-      p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
-      p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
+      p.on_tail("--version", ""){ |v| raise VersionExit, v.to_s }
+      p.on_tail("--help",    ""){ |v| raise HelpExit,    v.to_s }
     end
   end
 
@@ -24,14 +24,14 @@ class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
   end
   def to_s; @parser.to_s; end
   def inspect
-    "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
+    "#<#{self.class}:#{"0x0%x" % (object_id << 1)} @data=#{@data.inspect}>"
   end
 
   class Option
     attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
 
     def initialize(name, *args)
-      settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+      settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ""
       @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
       @value, @klass = gvalinfo(settings[:value])
       @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
@@ -44,8 +44,8 @@ class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
     private
 
     def parse_name_values(name, custom_abbrev)
-      [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
-        custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+      [ (processed_name = name.to_s.strip.downcase), processed_name.gsub("_", "-"),
+        custom_abbrev || processed_name.gsub(/[^a-z]/, "").chars.first || "a"
       ]
     end
     def gvalinfo(v); v.kind_of?(Class) ? [nil,v] : [v,v.class]; end

--- a/cli.rb
+++ b/cli.rb
@@ -48,7 +48,6 @@ class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
         custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
       ]
     end
-    def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
-    def gklass(k); k == Fixnum ? Integer : k; end
+    def gvalinfo(v); v.kind_of?(Class) ? [nil,v] : [v,v.class]; end
   end
 end

--- a/example.rb
+++ b/example.rb
@@ -1,6 +1,6 @@
 # 1. require in the cli.rb code (or paste it as MyCLI child class or something)
 
-require 'mycli/cli'
+require "mycli/cli"
 
 # 2. setup your CLI class, have it compose CLIRB (or sub-class or whatever)
 
@@ -26,15 +26,15 @@ class MyCLI
 
 # 3. inspect, validate, handle the opts and args
 
-      a = @cli.args; aa = a.map(&:inspect).join(', ')
+      a = @cli.args; aa = a.map(&:inspect).join(", ")
       raise CLIRB::Error, "too few arguments (#{a.size}): #{aa}"  if a.size < 2
       raise CLIRB::Error, "too many arguments (#{a.size}): #{aa}" if a.size > 2
 
-      @cli.opts['method'] ||= 'word'
-      @cli.opts['format'] ||= 'ascii' if @cli.opts['ascii']
-      @cli.opts['format'] ||= 'color' if @cli.opts['color']
-      @cli.opts['format'] ||= 'html'  if @cli.opts['html']
-      @cli.opts['format'] ||= 'ascii'
+      @cli.opts["method"] ||= "word"
+      @cli.opts["format"] ||= "ascii" if @cli.opts["ascii"]
+      @cli.opts["format"] ||= "color" if @cli.opts["color"]
+      @cli.opts["format"] ||= "html"  if @cli.opts["html"]
+      @cli.opts["format"] ||= "ascii"
 
       begin
 
@@ -67,5 +67,4 @@ class MyCLI
     "Usage: mycli [opts] LEFT RIGHT\n"\
     "#{@cli}"
   end
-
 end

--- a/test/cli_tests.rb
+++ b/test/cli_tests.rb
@@ -1,4 +1,4 @@
-require 'assert'
+require "assert"
 
 class CLITests < Assert::Context
   desc "CLI"
@@ -20,91 +20,87 @@ class CLITests < Assert::Context
   end
 
   should "raise `VersionExit` parsing `--version`" do
-    assert_raises(CLIRB::VersionExit) { cli_parse subject, '--version' }
+    assert_raises(CLIRB::VersionExit) { cli_parse subject, "--version" }
   end
 
   should "raise `HelpExit` when parsing `--help`" do
-    assert_raises(CLIRB::HelpExit) { cli_parse subject, '--help' }
+    assert_raises(CLIRB::HelpExit) { cli_parse subject, "--help" }
   end
 
   should "parse the args, opts, and full data" do
-    cli = CLIRB.new{ option 'verbose', 'verbosity'}
-    cli_parse(cli, 'an', 'arg', '-v')
+    cli = CLIRB.new{ option "verbose", "verbosity"}
+    cli_parse(cli, "an", "arg", "-v")
 
-    assert_equal ['an', 'arg'], cli.args
+    assert_equal ["an", "arg"], cli.args
     assert_kind_of Hash, cli.opts
     assert_equal 1, cli.opts.size
     assert_equal cli.args+[cli.opts], cli.data
   end
-
 end
 
 class SwitchTests < CLITests
   desc "when parsing a switch opt"
   setup do
-    @cli = CLIRB.new{ option 'verbose', 'verbosity'}
+    @cli = CLIRB.new{ option "verbose", "verbosity"}
   end
 
   should "default to niil" do
     subject.parse! []
-    assert_equal nil, subject.opts['verbose']
+    assert_equal nil, subject.opts["verbose"]
   end
 
   should "set true if abbrev" do
-    subject.parse! ['-v']
-    assert_equal true, subject.opts['verbose']
+    subject.parse! ["-v"]
+    assert_equal true, subject.opts["verbose"]
   end
 
   should "set true if full" do
-    subject.parse! ['--verbose']
-    assert_equal true, subject.opts['verbose']
+    subject.parse! ["--verbose"]
+    assert_equal true, subject.opts["verbose"]
   end
 
   should "set false if full negative" do
-    subject.parse! ['--no-verbose']
-    assert_equal false, subject.opts['verbose']
+    subject.parse! ["--no-verbose"]
+    assert_equal false, subject.opts["verbose"]
   end
-
 end
 
 class SingleValueTests < CLITests
   desc "when parsing a single value opt"
   setup do
-    @cli = CLIRB.new{ option 'skill', 'skillz', :value => '' }
+    @cli = CLIRB.new{ option "skill", "skillz", :value => "" }
   end
 
   should "set the default" do
     subject.parse! []
-    assert_equal '', subject.opts['skill']
+    assert_equal "", subject.opts["skill"]
   end
 
   should "set the value if abbrev" do
-    subject.parse! ['-s', 'booyah']
-    assert_equal 'booyah', subject.opts['skill']
+    subject.parse! ["-s", "booyah"]
+    assert_equal "booyah", subject.opts["skill"]
   end
 
   should "set the value if full" do
-    subject.parse! ['--skill', 'booyah']
-    assert_equal 'booyah', subject.opts['skill']
+    subject.parse! ["--skill", "booyah"]
+    assert_equal "booyah", subject.opts["skill"]
   end
 
   should "type-cast the value" do
-    cli = CLIRB.new{ option 'skill', 'skillz', :value => 1 }
-    cli.parse! ['-s', '12']
-    assert_equal 12, cli.opts['skill']
+    cli = CLIRB.new{ option "skill", "skillz", :value => 1 }
+    cli.parse! ["-s", "12"]
+    assert_equal 12, cli.opts["skill"]
   end
-
 end
 
 class ListValueTests < CLITests
   desc "when parsing a list value opt"
   setup do
-    @cli = CLIRB.new{ option 'skill', 'skillz', :value => [] }
+    @cli = CLIRB.new{ option "skill", "skillz", :value => [] }
   end
 
   should "set the list values by parsing the value as comma-separated" do
-    subject.parse! ['--skill', 'art,deco,eat,sleep']
-    assert_equal ['art', 'deco', 'eat', 'sleep'], subject.opts['skill']
+    subject.parse! ["--skill", "art,deco,eat,sleep"]
+    assert_equal ["art", "deco", "eat", "sleep"], subject.opts["skill"]
   end
-
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
-# this file is automatically required in when you require 'assert'
+# this file is automatically required in when you require "assert"
 # put test helpers here
 
 # add root dir to the load path
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
-require 'cli'
+require "cli"

--- a/test/option_tests.rb
+++ b/test/option_tests.rb
@@ -55,12 +55,6 @@ class OptionTests < Assert::Context
     assert_nil opt.value
     assert_equal String, opt.klass
   end
-
-  should "set the klass to Integer if given a Fixnum" do
-    assert_equal Integer, CLIRB::Option.new('test', '', :value => 1).klass
-    assert_equal Integer, CLIRB::Option.new('test', '', :value => Fixnum).klass
-  end
-
 end
 
 class SwitchOptTests < OptionTests

--- a/test/option_tests.rb
+++ b/test/option_tests.rb
@@ -1,57 +1,57 @@
-require 'assert'
+require "assert"
 
 class OptionTests < Assert::Context
   desc "an Option"
   setup do
-    @option = CLIRB::Option.new('test', "testing", :value => 'value')
+    @option = CLIRB::Option.new("test", "testing", :value => "value")
   end
   subject{ @option }
 
   should have_readers :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
 
   should "know its name and desc" do
-    assert_equal 'test', subject.name
-    assert_equal 'testing', subject.desc
+    assert_equal "test", subject.name
+    assert_equal "testing", subject.desc
   end
 
   should "know its value and klass" do
-    assert_equal 'value', subject.value
+    assert_equal "value", subject.value
     assert_equal String,  subject.klass
   end
 
   should "know its defaults" do
     opt_with_defaults = CLIRB::Option.new(:test)
-    assert_equal '',       opt_with_defaults.desc
+    assert_equal "",       opt_with_defaults.desc
     assert_equal nil,      opt_with_defaults.value
     assert_equal NilClass, opt_with_defaults.klass
   end
 
   should "force its name to a downcased string val" do
-    assert_equal 'test', CLIRB::Option.new(:Test).name
+    assert_equal "test", CLIRB::Option.new(:Test).name
   end
 
   should "parse its opt_name from the name" do
-    assert_equal 'test',        CLIRB::Option.new('test').opt_name
-    assert_equal 'testit',      CLIRB::Option.new('TestIt').opt_name
-    assert_equal 'test-it',     CLIRB::Option.new('test_it').opt_name
-    assert_equal 'test-it',     CLIRB::Option.new('Test_it').opt_name
-    assert_equal 'test-it-now', CLIRB::Option.new('test_it-now').opt_name
+    assert_equal "test",        CLIRB::Option.new("test").opt_name
+    assert_equal "testit",      CLIRB::Option.new("TestIt").opt_name
+    assert_equal "test-it",     CLIRB::Option.new("test_it").opt_name
+    assert_equal "test-it",     CLIRB::Option.new("Test_it").opt_name
+    assert_equal "test-it-now", CLIRB::Option.new("test_it-now").opt_name
   end
 
   should "parse its opt_abbrev from the first letter of the opt_name" do
-    assert_equal 't', CLIRB::Option.new('test').abbrev
-    assert_equal 'i', CLIRB::Option.new('it-test').abbrev
-    assert_equal 't', CLIRB::Option.new('123test').abbrev
-    assert_equal 't', CLIRB::Option.new('_test').abbrev
-    assert_equal 'a', CLIRB::Option.new('1234').abbrev
+    assert_equal "t", CLIRB::Option.new("test").abbrev
+    assert_equal "i", CLIRB::Option.new("it-test").abbrev
+    assert_equal "t", CLIRB::Option.new("123test").abbrev
+    assert_equal "t", CLIRB::Option.new("_test").abbrev
+    assert_equal "a", CLIRB::Option.new("1234").abbrev
   end
 
   should "override its opt_abbrev with the :abbrev setting" do
-    assert_equal 'x', CLIRB::Option.new('test', '', :abbrev => 'x').abbrev
+    assert_equal "x", CLIRB::Option.new("test", "", :abbrev => "x").abbrev
   end
 
   should "set its value to `nil` if given a Class :value" do
-    opt = CLIRB::Option.new('test', '', :value => String)
+    opt = CLIRB::Option.new("test", "", :value => String)
     assert_nil opt.value
     assert_equal String, opt.klass
   end
@@ -60,25 +60,23 @@ end
 class SwitchOptTests < OptionTests
   desc "that is a switch"
   setup do
-    @option = CLIRB::Option.new('test', "testing")
+    @option = CLIRB::Option.new("test", "testing")
   end
 
   should "use its opt_abbrev, opt_name, and desc in the parser_args" do
-    exp_args = ['-t', '--[no-]test', 'testing']
+    exp_args = ["-t", "--[no-]test", "testing"]
     assert_equal exp_args, subject.parser_args
   end
-
 end
 
 class ValueOptTests < OptionTests
   desc "that is not a switch"
   setup do
-    @option = CLIRB::Option.new('thing', "testing", :value => 'value')
+    @option = CLIRB::Option.new("thing", "testing", :value => "value")
   end
 
   should "use abbrev, name with VALUE, klass, and desc in the parser_args" do
-    exp_args = ['-t', '--thing THING', String, 'testing']
+    exp_args = ["-t", "--thing THING", String, "testing"]
     assert_equal exp_args, subject.parser_args
   end
-
 end


### PR DESCRIPTION
Ruby deprecated Fixnum in `2.4`. Version `2.3` was EOL'd earlier
this year so I feel OK removing support for it in a new version.

# Other Changes

### update to latest syntax conventions

* use double-quoted Strings
* no empty line at the end of Classes/Modules

Note: we still prefer hash-rocket Hash syntax so that isn't
changing.