### PR TITLE
always use the given option name as the option name

### DIFF
--- a/cli.rb
+++ b/cli.rb
@@ -31,8 +31,8 @@ class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
     attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
 
     def initialize(name, desc = nil, abbrev: nil, value: nil)
-      @desc = desc || ""
-      @name, @opt_name, @abbrev = parse_name_values(name, abbrev)
+      @name, @desc = name, desc || ""
+      @opt_name, @abbrev = parse_name_values(name, abbrev)
       @value, @klass = gvalinfo(value)
       @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
         ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
@@ -44,7 +44,7 @@ class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
     private
 
     def parse_name_values(name, custom_abbrev)
-      [ (processed_name = name.to_s.strip.downcase), processed_name.gsub("_", "-"),
+      [ (processed_name = name.to_s.strip.downcase).gsub("_", "-"),
         custom_abbrev || processed_name.gsub(/[^a-z]/, "").chars.first || "a"
       ]
     end

--- a/test/cli_tests.rb
+++ b/test/cli_tests.rb
@@ -96,11 +96,11 @@ end
 class ListValueTests < CLITests
   desc "when parsing a list value opt"
   setup do
-    @cli = CLIRB.new{ option "skill", "skillz", :value => [] }
+    @cli = CLIRB.new{ option :skill, "skillz", :value => [] }
   end
 
   should "set the list values by parsing the value as comma-separated" do
     subject.parse! ["--skill", "art,deco,eat,sleep"]
-    assert_equal ["art", "deco", "eat", "sleep"], subject.opts["skill"]
+    assert_equal ["art", "deco", "eat", "sleep"], subject.opts[:skill]
   end
 end

--- a/test/option_tests.rb
+++ b/test/option_tests.rb
@@ -21,13 +21,14 @@ class OptionTests < Assert::Context
 
   should "know its defaults" do
     opt_with_defaults = CLIRB::Option.new(:test)
+    assert_equal :test,    opt_with_defaults.name
     assert_equal "",       opt_with_defaults.desc
     assert_equal nil,      opt_with_defaults.value
     assert_equal NilClass, opt_with_defaults.klass
   end
 
-  should "force its name to a downcased string val" do
-    assert_equal "test", CLIRB::Option.new(:Test).name
+  should "always use the given name as the option name" do
+    assert_equal :Test, CLIRB::Option.new(:Test).name
   end
 
   should "parse its opt_name from the name" do


### PR DESCRIPTION
Even if it is a symbol or some weird value. The user needs to
expect to find their named option in the options hash using the
exact name value they gave.

Previously, this was converting all option names to downcased
strings. This was not documented in the README which used symbol
option names and then showed retreiving those option values using
the symbol name. This gets the implementation to matcht he README.
Plus this follows the principle of least surprise I think.